### PR TITLE
ZMS: optimize consecutive id reads

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -31,6 +31,15 @@ extern "C" {
  * @{
  */
 
+#if CONFIG_ZMS_LOOKUP_CACHE
+#define ZMS_READ_CACHE_SIZE (4)
+
+struct zms_read_cache_s {
+	uint64_t addr;
+	uint32_t id;
+};
+#endif
+
 /** Zephyr Memory Storage file system structure */
 struct zms_fs {
 	/** File system offset in flash */
@@ -64,8 +73,7 @@ struct zms_fs {
 #if CONFIG_ZMS_LOOKUP_CACHE
 	/** Lookup table used to cache ATE addresses of written IDs */
 	uint64_t lookup_cache[CONFIG_ZMS_LOOKUP_CACHE_SIZE];
-	uint64_t last_read_addr;
-	uint32_t last_read_id;
+	struct zms_read_cache_s last_read[ZMS_READ_CACHE_SIZE];
 	uint32_t highest_id_in_use;
 	uint32_t lowest_id_in_use;
 	int32_t num_valid_ates;

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -72,6 +72,7 @@ struct zms_fs {
 	const char *name;
 	bool highest_id_in_use_valid;
 	bool lowest_id_in_use_valid;
+	bool invalidate_old_ates;
 #endif
 };
 

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -68,7 +68,7 @@ struct zms_fs {
 	uint32_t last_read_id;
 	uint32_t highest_id_in_use;
 	uint32_t lowest_id_in_use;
-	int32_t num_entries; // this is not exact!
+	int32_t num_valid_ates;
 	const char *name;
 	bool highest_id_in_use_valid;
 	bool lowest_id_in_use_valid;
@@ -92,7 +92,7 @@ struct zms_fs {
 // Using int32_t ids (and neg. error codes) would be much nicer, but break with zms assumptions
 int zms_get_highest_id_in_use(const struct zms_fs *fs, uint32_t *id);
 int zms_get_lowest_id_in_use(const struct zms_fs *fs, uint32_t *id);
-int32_t zms_get_num_entries(const struct zms_fs *fs);
+int32_t zms_get_num_entries(const struct zms_fs *fs); // this might not be exact!
 #endif
 
 /**

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -32,7 +32,7 @@ extern "C" {
  */
 
 #if CONFIG_ZMS_LOOKUP_CACHE
-#define ZMS_READ_CACHE_SIZE (4)
+#define ZMS_READ_CACHE_SIZE (1)
 
 struct zms_read_cache_s {
 	uint64_t addr;

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -64,6 +64,14 @@ struct zms_fs {
 #if CONFIG_ZMS_LOOKUP_CACHE
 	/** Lookup table used to cache ATE addresses of written IDs */
 	uint64_t lookup_cache[CONFIG_ZMS_LOOKUP_CACHE_SIZE];
+	uint64_t last_read_addr;
+	uint32_t last_read_id;
+	uint32_t highest_id_in_use;
+	uint32_t lowest_id_in_use;
+	int32_t num_entries; // this is not exact!
+	const char *name;
+	bool highest_id_in_use_valid;
+	bool lowest_id_in_use_valid;
 #endif
 };
 
@@ -76,6 +84,15 @@ struct zms_fs {
  * @ingroup zms
  * @{
  */
+
+// TODO: we should probably define our own config (and define the dependencies)
+#if CONFIG_ZMS_LOOKUP_CACHE
+// TODO: clean-up and verify these functions and associated vars (for deletion etc.)
+// Using int32_t ids (and neg. error codes) would be much nicer, but break with zms assumptions
+int zms_get_highest_id_in_use(const struct zms_fs *fs, uint32_t *id);
+int zms_get_lowest_id_in_use(const struct zms_fs *fs, uint32_t *id);
+int32_t zms_get_num_entries(const struct zms_fs *fs);
+#endif
 
 /**
  * @brief Mount a ZMS file system onto the device specified in `fs`.

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -60,7 +60,6 @@ static void zms_invalidate_ate(struct zms_ate *ate)
 {
 	ate->len = 0;
 	if (zms_ate_crc8_check(ate)) {
-		LOG_DBG("%s: wrote invalid ate for id %u", __func__, ate->id);
 		return; // the existing CRC is already wrong / invalid
 	}
 	if (ate->crc8) {
@@ -86,6 +85,129 @@ static void zms_invalidate_ate(struct zms_ate *ate)
 	}
 	// This LOG_ERR() is never hit: the all-0 ate is in fact invalid
 	LOG_ERR("%s: all-0 ate was marked valid!", __func__);
+}
+
+static inline size_t zms_read_cache_pos(uint32_t id)
+{
+	return id % ZMS_READ_CACHE_SIZE;
+}
+
+static void zms_read_cache_update(struct zms_fs *fs, uint32_t id, uint64_t ate_addr,
+				  bool exists_now, bool existed_before)
+{
+	if (id == ZMS_HEAD_ID) {
+		return;
+	}
+	struct zms_read_cache_s *cp = &fs->last_read[zms_read_cache_pos(id)];
+	if (exists_now) {
+		cp->addr = ate_addr;
+		cp->id = id;
+		if (!fs->highest_id_in_use_valid || (id > fs->highest_id_in_use)) {
+			fs->highest_id_in_use = id;
+			fs->highest_id_in_use_valid = true;
+		}
+		if (!fs->lowest_id_in_use_valid || (id < fs->lowest_id_in_use)) {
+			fs->lowest_id_in_use = id;
+			fs->lowest_id_in_use_valid = true;
+		}
+	} else {
+		if (cp->id == id) {
+			cp->addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+		}
+		if (fs->highest_id_in_use_valid && (id == fs->highest_id_in_use)) {
+			fs->highest_id_in_use_valid = (id > 0) && fs->lowest_id_in_use_valid &&
+						      (id > fs->lowest_id_in_use);
+			fs->highest_id_in_use = id - 1;
+		}
+		if (fs->lowest_id_in_use_valid && (id == fs->lowest_id_in_use)) {
+			fs->lowest_id_in_use_valid = (id < UINT32_MAX) &&
+						     fs->highest_id_in_use_valid &&
+						     (id < fs->highest_id_in_use);
+			fs->lowest_id_in_use = id + 1;
+		}
+	}
+	if (fs->num_valid_ates >= 0) {
+		int8_t d = (exists_now ? 1 : 0) - (existed_before ? 1 : 0);
+		fs->num_valid_ates += d;
+	}
+	bool strange = false;
+	if (fs->num_valid_ates > 0) {
+		if (!fs->highest_id_in_use_valid || !fs->lowest_id_in_use_valid) {
+			strange = true;
+		} else if (fs->num_valid_ates >
+			   (1 + fs->highest_id_in_use - fs->lowest_id_in_use)) {
+			strange = true;
+		}
+	} else if (fs->num_valid_ates < 0) {
+		strange = true;
+	} else if (fs->highest_id_in_use_valid || fs->lowest_id_in_use_valid) {
+		strange = true;
+	}
+	if (strange && fs->invalidate_old_ates) {
+		LOG_WRN("%s: %s: id: %u, e: %d, b: %d, num_valid_ates: %d, highest_id_in_use: %u "
+			"(%svalid), lowest_id_in_use: %u (%svalid)",
+			__func__, fs->name ? fs->name : "?", id, exists_now, existed_before,
+			fs->num_valid_ates, fs->highest_id_in_use,
+			fs->highest_id_in_use_valid ? "" : "in", fs->lowest_id_in_use,
+			fs->lowest_id_in_use_valid ? "" : "in");
+	} else {
+		LOG_DBG("%s: %s: id: %u, e: %d, b: %d, num_valid_ates: %d, highest_id_in_use: %u "
+			"(%svalid), lowest_id_in_use: %u (%svalid)",
+			__func__, fs->name ? fs->name : "?", id, exists_now, existed_before,
+			fs->num_valid_ates, fs->highest_id_in_use,
+			fs->highest_id_in_use_valid ? "" : "in", fs->lowest_id_in_use,
+			fs->lowest_id_in_use_valid ? "" : "in");
+	}
+}
+
+static int zms_compute_prev_addr(struct zms_fs *fs, uint64_t *addr);
+static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_addr,
+				uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr,
+				int32_t *loop_cnt, int32_t loop_cnt_max);
+
+static int zms_quick_find_ate_with_id(struct zms_fs *fs, uint32_t id, struct zms_ate *ate,
+				      uint64_t *ate_addr, int32_t *loop_cnt)
+{
+#define ID_MATCH_RANGE (10)
+	const uint32_t id_min = (id > ID_MATCH_RANGE) ? (id - ID_MATCH_RANGE) : 0;
+	const uint32_t id_max =
+		(id < UINT32_MAX - ID_MATCH_RANGE) ? (id + ID_MATCH_RANGE) : UINT32_MAX;
+	int found = 0;
+	int32_t loop_cnt_l = 0;
+	if (!loop_cnt) {
+		loop_cnt = &loop_cnt_l;
+	}
+	for (uint32_t i = id; i < (id + ZMS_READ_CACHE_SIZE); ++i) {
+		int rc = 0;
+		struct zms_read_cache_s *cp = &fs->last_read[zms_read_cache_pos(i)];
+		if ((cp->addr == ZMS_LOOKUP_CACHE_NO_ADDR) || (cp->id < id_min) ||
+		    (cp->id > id_max)) {
+			continue;
+		}
+		uint64_t start_addr = cp->addr;
+		if (id > cp->id) {
+			uint32_t d = id - cp->id;
+			if (d > ID_MATCH_RANGE) {
+				d = ID_MATCH_RANGE;
+			}
+			for (uint32_t j = 0; j < d; ++j) {
+				// TODO: this is a primitive heuristic; implement a real function
+				const uint64_t next_addr = start_addr - fs->ate_size;
+				uint64_t t = next_addr;
+				rc = zms_compute_prev_addr(fs, &t);
+				if ((rc < 0) || (t != start_addr)) {
+					break;
+				}
+				start_addr = next_addr;
+			}
+		}
+		found = zms_find_ate_with_id(fs, id, start_addr, start_addr, ate, ate_addr,
+					     loop_cnt, *loop_cnt + 2 * ID_MATCH_RANGE);
+		if (found) {
+			break;
+		}
+	}
+	return found;
 }
 
 static inline size_t zms_lookup_cache_pos(uint32_t id)
@@ -115,13 +237,15 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 	int32_t loop_count = 0;
 
 	memset(fs->lookup_cache, 0xff, sizeof(fs->lookup_cache));
-	fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
-	fs->last_read_id = UINT32_MAX;
-	fs->highest_id_in_use = UINT32_MAX;
-	fs->lowest_id_in_use = UINT32_MAX;
+	for (int8_t i = 0; i < ZMS_READ_CACHE_SIZE; ++i) {
+		fs->last_read[i].addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+		fs->last_read[i].id = UINT32_MAX;
+	}
 	fs->highest_id_in_use_valid = false;
 	fs->lowest_id_in_use_valid = false;
 	fs->num_valid_ates = 0;
+	fs->highest_id_in_use = UINT32_MAX;
+	fs->lowest_id_in_use = UINT32_MAX;
 
 	addr = fs->ate_wra;
 
@@ -160,17 +284,7 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 						cache_entry - fs->lookup_cache, ate.id,
 						(uint32_t)(ate_addr >> 32), (uint32_t)ate_addr);
 				}
-				if ((ate.id > fs->highest_id_in_use) ||
-				    (!fs->highest_id_in_use_valid)) {
-					fs->highest_id_in_use = ate.id;
-					fs->highest_id_in_use_valid = true;
-				}
-				if ((ate.id < fs->lowest_id_in_use) ||
-				    (!fs->lowest_id_in_use_valid)) {
-					fs->lowest_id_in_use = ate.id;
-					fs->lowest_id_in_use_valid = true;
-				}
-				++fs->num_valid_ates;
+				zms_read_cache_update(fs, ate.id, ate_addr, true, false);
 			}
 			previous_sector_num = SECTOR_NUM(ate_addr);
 		}
@@ -195,8 +309,10 @@ static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 			*cache_entry = ZMS_LOOKUP_CACHE_NO_ADDR;
 		}
 	}
-	fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
-	fs->last_read_id = UINT32_MAX;
+	for (int8_t i = 0; i < ZMS_READ_CACHE_SIZE; ++i) {
+		fs->last_read[i].addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+		fs->last_read[i].id = UINT32_MAX;
+	}
 }
 
 #endif /* CONFIG_ZMS_LOOKUP_CACHE */
@@ -922,11 +1038,11 @@ static int zms_get_sector_header(struct zms_fs *fs, uint64_t addr, struct zms_at
  */
 static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_addr,
 				uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr,
-				int32_t *loop_cnt)
+				int32_t *loop_cnt, int32_t loop_cnt_max)
 {
 	int rc;
 	int previous_sector_num = ZMS_INVALID_SECTOR_NUM;
-	uint64_t wlk_prev_addr;
+	uint64_t wlk_prev_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
 	uint64_t wlk_addr;
 	int prev_found = 0;
 	struct zms_ate wlk_ate;
@@ -934,15 +1050,24 @@ static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_a
 
 	wlk_addr = start_addr;
 
+	bool first_sect_border_seen = false;
+	uint32_t end_sect = ZMS_INVALID_SECTOR_NUM;
+	int32_t loop_cnt_l = 0;
+	if (!loop_cnt) {
+		loop_cnt = &loop_cnt_l;
+	}
+	if (loop_cnt_max && (*loop_cnt >= loop_cnt_max)) {
+		return 0;
+	}
+
 	do {
-		if (loop_cnt) {
-			*loop_cnt += 1;
-		}
+		*loop_cnt += 1;
 		wlk_prev_addr = wlk_addr;
 		rc = zms_prev_ate(fs, &wlk_addr, &wlk_ate);
 		if (rc) {
 			return rc;
 		}
+		const int32_t prev_sect = SECTOR_NUM(wlk_prev_addr);
 		if (wlk_ate.id == id) {
 			/* read the ate cycle only when we change the sector or if it is
 			 * the first read ( previous_sector_num == ZMS_INVALID_SECTOR_NUM).
@@ -956,13 +1081,36 @@ static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_a
 				prev_found = 1;
 				break;
 			}
-			previous_sector_num = SECTOR_NUM(wlk_prev_addr);
+			previous_sector_num = prev_sect;
 		}
-	} while (wlk_addr != end_addr);
+		const int32_t current_sect = SECTOR_NUM(wlk_addr);
+		if (current_sect != prev_sect) {
+			if (first_sect_border_seen) {
+				if (current_sect == end_sect) {
+					break;
+				}
+			} else {
+				end_sect = current_sect;
+				first_sect_border_seen = true;
+			}
+		}
+	} while ((wlk_addr != end_addr) && (!loop_cnt_max || (*loop_cnt < loop_cnt_max)));
 
-	*ate = wlk_ate;
-	*ate_addr = wlk_prev_addr;
-
+	if (prev_found > 0) {
+		if (ate) {
+			*ate = wlk_ate;
+		}
+		if (ate_addr) {
+			*ate_addr = wlk_prev_addr;
+		}
+	}
+	if (*loop_cnt >= 100000) {
+		LOG_DBG("%s: loop_cnt: %d, id: %d, sa: 0x%llx, ea: 0x%llx, atea: "
+			"0x%llx, wa: 0x%llx, wpa: 0x%llx, first_sect_border_seen: "
+			"%d @ 0x%x",
+			__func__, *loop_cnt, id, start_addr, end_addr, *ate_addr, wlk_addr,
+			wlk_prev_addr, first_sect_border_seen, end_sect);
+	}
 	return prev_found;
 }
 
@@ -1045,7 +1193,11 @@ static int zms_gc(struct zms_fs *fs)
 			return rc;
 		}
 
-		if (!zms_ate_valid(fs, &gc_ate) || !gc_ate.len) {
+		if (!zms_ate_valid(fs, &gc_ate)) {
+			continue;
+		}
+		if (!gc_ate.len) {
+			zms_read_cache_update(fs, gc_ate.id, ZMS_LOOKUP_CACHE_NO_ADDR, false, true);
 			continue;
 		}
 
@@ -1064,10 +1216,18 @@ static int zms_gc(struct zms_fs *fs)
 		/* Search for a previous valid ATE with the same ID. If it doesn't exist
 		 * then wlk_prev_addr will be equal to gc_prev_addr.
 		 */
-		rc = zms_find_ate_with_id(fs, gc_ate.id, wlk_addr, fs->ate_wra, &wlk_ate,
-					  &wlk_prev_addr, NULL);
-		if (rc < 0) {
-			return rc;
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+		if (fs->invalidate_old_ates) {
+			// no need to search: we know there is only max. 1 valid ate per id
+			rc = 0;
+		} else
+#endif
+		{
+			rc = zms_find_ate_with_id(fs, gc_ate.id, wlk_addr, fs->ate_wra, &wlk_ate,
+						  &wlk_prev_addr, NULL, 0);
+			if (rc < 0) {
+				return rc;
+			}
 		}
 
 		/* if walk_addr has reached the same address as gc_addr, a copy is
@@ -1093,6 +1253,7 @@ static int zms_gc(struct zms_fs *fs)
 
 			gc_ate.cycle_cnt = previous_cycle;
 			zms_ate_crc8_update(&gc_ate);
+			zms_read_cache_update(fs, gc_ate.id, fs->ate_wra, true, true);
 			rc = zms_flash_ate_wrt(fs, &gc_ate);
 			if (rc) {
 				return rc;
@@ -1536,7 +1697,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 		prev_found = 0;
 	} else {
 		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate, &rd_addr,
-						  &loop_count);
+						  &loop_count, 0);
 	}
 	if (prev_found < 0) {
 		return prev_found;
@@ -1558,6 +1719,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 				/* skip delete entry as it is already the
 				 * last one
 				 */
+				zms_read_cache_update(fs, id, rd_addr, true, true);
 				return 0;
 			}
 #ifdef ZMS_DONT_KEEP_HISTORY
@@ -1575,12 +1737,6 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 					// TODO: we could try to protect this using a read mutex,
 					// but I consider that too expensive atm.
 				}
-				// Deleting an entry that indeed existed before
-				// We don't try to track highest and lowest id in use here:
-				// it would require rescanning all ATEs to be correct
-			}
-			if (fs->num_valid_ates >= 0) {
-				--fs->num_valid_ates;
 			}
 #endif
 		} else if (len == wlk_ate.len) {
@@ -1621,10 +1777,8 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	} else {
 		/* skip delete entry for non-existing entry */
 		if (len == 0) {
+			zms_read_cache_update(fs, id, ZMS_LOOKUP_CACHE_NO_ADDR, false, false);
 			return 0;
-		}
-		if (fs->num_valid_ates >= 0) {
-			++fs->num_valid_ates;
 		}
 	}
 #endif
@@ -1680,14 +1834,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	}
 	rc = len;
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	if ((id > fs->highest_id_in_use) || (!fs->highest_id_in_use_valid)) {
-		fs->highest_id_in_use = id;
-		fs->highest_id_in_use_valid = true;
-	}
-	if ((id < fs->lowest_id_in_use) || (!fs->lowest_id_in_use_valid)) {
-		fs->lowest_id_in_use = id;
-		fs->lowest_id_in_use_valid = true;
-	}
+	zms_read_cache_update(fs, id, fs->ate_wra, true, prev_found > 0);
 	LOG_DBG("%s: %s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d), "
 		"num_valid_ates: %d, lowest id: %u, highest id: %u",
 		__func__, (fs->name) ? fs->name : "?", id, len, loop_count, gc_count,
@@ -1727,33 +1874,18 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	cnt_his = 0U;
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-#define ID_MATCH_RANGE 1
-	const uint32_t id_min =
-		(fs->last_read_id > ID_MATCH_RANGE) ? (fs->last_read_id - ID_MATCH_RANGE) : 0;
-	const uint32_t id_max = (fs->last_read_id < UINT32_MAX - ID_MATCH_RANGE)
-					? (fs->last_read_id + ID_MATCH_RANGE)
-					: UINT32_MAX;
-	if (fs->invalidate_old_ates && (id >= id_min) && (id <= id_max) &&
-	    (fs->last_read_addr != ZMS_LOOKUP_CACHE_NO_ADDR)) {
-		wlk_addr = fs->last_read_addr;
-		if (id > fs->last_read_id) {
-			const uint32_t d = id - fs->last_read_id;
-			for (uint32_t i = 0; i < d; ++i) {
-				// TODO: this is a primitive heuristic; implement a real
-				// function
-				const uint64_t next_addr = wlk_addr - fs->ate_size;
-				uint64_t t = next_addr;
-				rc = zms_compute_prev_addr(fs, &t);
-				if ((rc < 0) || (t != wlk_addr)) {
-					wlk_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
-					break;
-				}
-				wlk_addr = next_addr;
-			}
+	wlk_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+	if (fs->invalidate_old_ates) {
+		if (fs->highest_id_in_use_valid && (id > fs->highest_id_in_use)) {
+			return -ENOENT;
 		}
-		end_addr = wlk_addr;
-	} else {
-		wlk_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+		if (fs->lowest_id_in_use_valid && (id < fs->lowest_id_in_use)) {
+			return -ENOENT;
+		}
+		rc = zms_quick_find_ate_with_id(fs, id, NULL, &wlk_addr, &loop_count);
+		if (rc < 0) {
+			return rc;
+		}
 	}
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
 		wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
@@ -1762,6 +1894,8 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 			goto err;
 		}
 		end_addr = fs->ate_wra;
+	} else {
+		end_addr = wlk_addr;
 	}
 #else
 	wlk_addr = fs->ate_wra;
@@ -1772,7 +1906,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 		wlk_prev_addr = wlk_addr;
 		/* Search for a previous valid ATE with the same ID */
 		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, end_addr, &wlk_ate,
-						  &wlk_prev_addr, &loop_count);
+						  &wlk_prev_addr, &loop_count, 0);
 		if (prev_found < 0) {
 			return prev_found;
 		}
@@ -1796,13 +1930,10 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	}
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	LOG_DBG("%s: %s: id: %u, cnt: %d, prev_id: %u, addr: 0x%0x'%08x, ate loops: %d", __func__,
-		(fs->name) ? fs->name : "?", id, cnt, fs->last_read_id, (uint32_t)(wlk_addr >> 32),
-		(uint32_t)(wlk_addr & INT32_MAX), loop_count);
-	if ((cnt == 0) && prev_found) {
-		fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
-		fs->last_read_id = id;
-		fs->last_read_addr = rd_addr;
+	LOG_DBG("%s: %s: id: %u, cnt: %d, addr: 0x%llx, ate loops: %d", __func__,
+		(fs->name) ? fs->name : "?", id, cnt, wlk_addr, loop_count);
+	if (cnt == 0) {
+		zms_read_cache_update(fs, id, rd_addr, prev_found > 0, true);
 	}
 #endif
 
@@ -1926,7 +2057,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 		wlk_addr = step_addr;
 		/* Try to find if there is a previous valid ATE with same ID */
 		prev_found = zms_find_ate_with_id(fs, step_ate.id, wlk_addr, step_addr, &wlk_ate,
-						  &wlk_prev_addr, NULL);
+						  &wlk_prev_addr, NULL, 0);
 		if (prev_found < 0) {
 			return prev_found;
 		}

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -197,11 +197,6 @@ static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 	}
 	fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
 	fs->last_read_id = UINT32_MAX;
-	fs->highest_id_in_use = UINT32_MAX;
-	fs->lowest_id_in_use = UINT32_MAX;
-	fs->highest_id_in_use_valid = false;
-	fs->lowest_id_in_use_valid = false;
-	fs->num_valid_ates = -1;
 }
 
 #endif /* CONFIG_ZMS_LOOKUP_CACHE */
@@ -1524,7 +1519,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
 
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
-		goto no_cached_entry;
+		wlk_addr = fs->ate_wra;
 	}
 #else
 	wlk_addr = fs->ate_wra;
@@ -1634,9 +1629,6 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	}
 #endif
 
-#ifdef CONFIG_ZMS_LOOKUP_CACHE
-no_cached_entry:
-#endif
 	/* calculate required space if the entry contains data */
 	if (data_size) {
 		/* Leave space for delete ate */
@@ -1696,8 +1688,10 @@ no_cached_entry:
 		fs->lowest_id_in_use = id;
 		fs->lowest_id_in_use_valid = true;
 	}
-	LOG_DBG("%s: %s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d)", __func__,
-		(fs->name) ? fs->name : "?", id, len, loop_count, gc_count, fs->sector_count);
+	LOG_DBG("%s: %s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d), "
+		"num_valid_ates: %d, lowest id: %u, highest id: %u",
+		__func__, (fs->name) ? fs->name : "?", id, len, loop_count, gc_count,
+		fs->sector_count, fs->num_valid_ates, fs->lowest_id_in_use, fs->highest_id_in_use);
 #endif
 
 end:

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -25,6 +25,68 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 					  uint8_t cycle_cnt);
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
+#define ZMS_DONT_KEEP_HISTORY 1
+
+int zms_get_highest_id_in_use(const struct zms_fs *fs, uint32_t *id)
+{
+	if (!fs->highest_id_in_use_valid) {
+		return -ENOENT;
+	}
+	if (id) {
+		*id = fs->highest_id_in_use;
+	}
+	return 0;
+}
+
+int zms_get_lowest_id_in_use(const struct zms_fs *fs, uint32_t *id)
+{
+	if (!fs->lowest_id_in_use_valid) {
+		return -ENOENT;
+	}
+	if (id) {
+		*id = fs->lowest_id_in_use;
+	}
+	return 0;
+}
+
+int32_t zms_get_num_entries(const struct zms_fs *fs)
+{
+	return fs->num_entries;
+}
+
+static int zms_ate_crc8_check(const struct zms_ate *entry);
+
+static void zms_invalidate_ate(struct zms_ate *ate)
+{
+	ate->len = 0;
+	if (zms_ate_crc8_check(ate)) {
+		LOG_DBG("%s: wrote invalid ate for id %u", __func__, ate->id);
+		return; // the existing CRC is already wrong / invalid
+	}
+	if (ate->crc8) {
+		const uint8_t lsb = LSB_GET(ate->crc8);
+		const uint8_t orig_crc = ate->crc8;
+		ate->crc8 = orig_crc & ~lsb; // make the lowest 1 bit -> 0
+		if (zms_ate_crc8_check(ate)) {
+			LOG_DBG("%s: wrote invalid crc8 0x%x for id %u (by deleting 0x%x from "
+				"0x%x)",
+				__func__, ate->crc8, ate->id, lsb, orig_crc);
+			return;
+		} else {
+			LOG_ERR("%s: could not invalidate crc8 0x%x for id %u (by deleting 0x%x "
+				"from 0x%x)",
+				__func__, ate->crc8, ate->id, lsb, orig_crc);
+		}
+	}
+	// It should always be possible to write the all-0 ate
+	memset(ate, 0, sizeof(struct zms_ate));
+	if (zms_ate_crc8_check(ate)) {
+		LOG_DBG("%s: wrote invalid all-0 ate", __func__);
+		return;
+	}
+	// This LOG_ERR() is never hit: the all-0 ate is in fact invalid
+	LOG_ERR("%s: all-0 ate was marked valid!", __func__);
+}
 
 static inline size_t zms_lookup_cache_pos(uint32_t id)
 {
@@ -50,11 +112,21 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 	uint64_t *cache_entry;
 	uint8_t current_cycle;
 	struct zms_ate ate;
+	int32_t loop_count = 0;
 
 	memset(fs->lookup_cache, 0xff, sizeof(fs->lookup_cache));
+	fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+	fs->last_read_id = UINT32_MAX;
+	fs->highest_id_in_use = UINT32_MAX;
+	fs->lowest_id_in_use = UINT32_MAX;
+	fs->highest_id_in_use_valid = false;
+	fs->lowest_id_in_use_valid = false;
+	fs->num_entries = 0;
+
 	addr = fs->ate_wra;
 
 	while (true) {
+		++loop_count;
 		/* Make a copy of 'addr' as it will be advanced by zms_prev_ate() */
 		ate_addr = addr;
 		rc = zms_prev_ate(fs, &addr, &ate);
@@ -65,7 +137,7 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 
 		cache_entry = &fs->lookup_cache[zms_lookup_cache_pos(ate.id)];
 
-		if (ate.id != ZMS_HEAD_ID && *cache_entry == ZMS_LOOKUP_CACHE_NO_ADDR) {
+		if (ate.id != ZMS_HEAD_ID) {
 			/* read the ate cycle only when we change the sector
 			 * or if it is the first read
 			 */
@@ -80,7 +152,27 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 				}
 			}
 			if (zms_ate_valid_different_sector(fs, &ate, current_cycle)) {
-				*cache_entry = ate_addr;
+				if (*cache_entry == ZMS_LOOKUP_CACHE_NO_ADDR) {
+					*cache_entry = ate_addr;
+					LOG_DBG("%s: %s: assigned cache entry %2d: id %10u -> "
+						"%3d:0x%08x",
+						__func__, (fs->name) ? fs->name : "?",
+						cache_entry - fs->lookup_cache, ate.id,
+						(uint32_t)(ate_addr >> 32), (uint32_t)ate_addr);
+				}
+				if (ate.id < 0x7ffffffeUL) { /* TODO: FIXME: remove this */
+					if ((ate.id > fs->highest_id_in_use) ||
+					    (!fs->highest_id_in_use_valid)) {
+						fs->highest_id_in_use = ate.id;
+						fs->highest_id_in_use_valid = true;
+					}
+					if ((ate.id < fs->lowest_id_in_use) ||
+					    (!fs->lowest_id_in_use_valid)) {
+						fs->lowest_id_in_use = ate.id;
+						fs->lowest_id_in_use_valid = true;
+					}
+				}
+				++fs->num_entries;
 			}
 			previous_sector_num = SECTOR_NUM(ate_addr);
 		}
@@ -89,6 +181,8 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 			break;
 		}
 	}
+	LOG_DBG("%s: done for fs %s, loop_count: %d", __func__, (fs->name) ? fs->name : "?",
+		loop_count);
 
 	return 0;
 }
@@ -103,6 +197,13 @@ static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 			*cache_entry = ZMS_LOOKUP_CACHE_NO_ADDR;
 		}
 	}
+	fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+	fs->last_read_id = UINT32_MAX;
+	fs->highest_id_in_use = UINT32_MAX;
+	fs->lowest_id_in_use = UINT32_MAX;
+	fs->highest_id_in_use_valid = false;
+	fs->lowest_id_in_use_valid = false;
+	fs->num_entries = -1;
 }
 
 #endif /* CONFIG_ZMS_LOOKUP_CACHE */
@@ -827,7 +928,8 @@ static int zms_get_sector_header(struct zms_fs *fs, uint64_t addr, struct zms_at
  * @retval < 0 An error happened
  */
 static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_addr,
-				uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr)
+				uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr,
+				int32_t *loop_cnt)
 {
 	int rc;
 	int previous_sector_num = ZMS_INVALID_SECTOR_NUM;
@@ -840,6 +942,9 @@ static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_a
 	wlk_addr = start_addr;
 
 	do {
+		if (loop_cnt) {
+			*loop_cnt += 1;
+		}
 		wlk_prev_addr = wlk_addr;
 		rc = zms_prev_ate(fs, &wlk_addr, &wlk_ate);
 		if (rc) {
@@ -967,7 +1072,7 @@ static int zms_gc(struct zms_fs *fs)
 		 * then wlk_prev_addr will be equal to gc_prev_addr.
 		 */
 		rc = zms_find_ate_with_id(fs, gc_ate.id, wlk_addr, fs->ate_wra, &wlk_ate,
-					  &wlk_prev_addr);
+					  &wlk_prev_addr, NULL);
 		if (rc < 0) {
 			return rc;
 		}
@@ -1397,6 +1502,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	uint64_t rd_addr;
 	uint32_t gc_count;
 	uint32_t required_space = 0U; /* no space, appropriate for delete ate */
+	int32_t loop_count = 0;
 
 	if (!fs->ready) {
 		LOG_ERR("zms not initialized");
@@ -1430,12 +1536,23 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 #ifdef CONFIG_ZMS_NO_DOUBLE_WRITE
 	/* Search for a previous valid ATE with the same ID */
 	struct zms_ate wlk_ate;
-	int prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate, &rd_addr);
+	int prev_found = -1;
+	if (fs->highest_id_in_use_valid && (fs->highest_id_in_use < id)) {
+		prev_found = 0;
+	} else if (fs->lowest_id_in_use_valid && (fs->lowest_id_in_use > id)) {
+		prev_found = 0;
+	} else {
+		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate, &rd_addr,
+						  &loop_count);
+	}
 	if (prev_found < 0) {
 		return prev_found;
 	}
 
 	if (prev_found) {
+#ifdef ZMS_DONT_KEEP_HISTORY
+		const uint64_t ate_addr = rd_addr;
+#endif
 		/* previous entry found */
 		if (len > ZMS_DATA_IN_ATE_SIZE) {
 			rd_addr &= ADDR_SECT_MASK;
@@ -1450,6 +1567,39 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 				 */
 				return 0;
 			}
+#ifdef ZMS_DONT_KEEP_HISTORY
+			else {
+				zms_invalidate_ate(&wlk_ate);
+				// TODO: I think we don't need to k_mutex_lock(&fs->zms_lock,
+				// K_FOREVER); for this, right?
+				rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate, sizeof(wlk_ate));
+				if (rc < 0) {
+					return rc;
+				}
+				// deleting an entry that indeed existed before
+				if (fs->highest_id_in_use_valid && (fs->highest_id_in_use == id)) {
+					if (id > 0) {
+						--fs->highest_id_in_use;
+						// TODO: this probably wrong; fix for delete use
+						// case
+					} else {
+						fs->highest_id_in_use_valid = false;
+						fs->lowest_id_in_use_valid = false;
+					}
+				}
+				if (fs->lowest_id_in_use_valid && (fs->lowest_id_in_use == id)) {
+					if (id < fs->highest_id_in_use) {
+						++fs->lowest_id_in_use;
+					}
+				} else {
+					fs->highest_id_in_use_valid = false;
+					fs->lowest_id_in_use_valid = false;
+				}
+			}
+			if (fs->num_entries >= 0) {
+				--fs->num_entries;
+			}
+#endif
 		} else if (len == wlk_ate.len) {
 			/* do not try to compare if lengths are not equal */
 			/* compare the data and if equal return 0 */
@@ -1458,17 +1608,40 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 				if (!rc) {
 					return 0;
 				}
+#ifdef ZMS_DONT_KEEP_HISTORY
+				else {
+					zms_invalidate_ate(&wlk_ate);
+					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
+							      sizeof(wlk_ate));
+					if (rc < 0) {
+						return rc;
+					}
+				}
+#endif
 			} else {
 				rc = zms_flash_block_cmp(fs, rd_addr, data, len);
 				if (rc <= 0) {
 					return rc;
 				}
+#ifdef ZMS_DONT_KEEP_HISTORY
+				else {
+					zms_invalidate_ate(&wlk_ate);
+					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
+							      sizeof(wlk_ate));
+					if (rc < 0) {
+						return rc;
+					}
+				}
+#endif
 			}
 		}
 	} else {
 		/* skip delete entry for non-existing entry */
 		if (len == 0) {
 			return 0;
+		}
+		if (fs->num_entries >= 0) {
+			++fs->num_entries;
 		}
 	}
 #endif
@@ -1526,6 +1699,19 @@ no_cached_entry:
 		gc_count++;
 	}
 	rc = len;
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+	if ((id > fs->highest_id_in_use) || (!fs->highest_id_in_use_valid)) {
+		fs->highest_id_in_use = id;
+		fs->highest_id_in_use_valid = true;
+	}
+	if ((id < fs->lowest_id_in_use) || (!fs->lowest_id_in_use_valid)) {
+		fs->lowest_id_in_use = id;
+		fs->lowest_id_in_use_valid = true;
+	}
+	LOG_DBG("%s: %s: ate search loops: %d, gc loops: %d (max. %d) for id: %u", __func__,
+		(fs->name) ? fs->name : "?", loop_count, gc_count, fs->sector_count, id);
+#endif
+
 end:
 	k_mutex_unlock(&fs->zms_lock);
 	return rc;
@@ -1541,10 +1727,12 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	int rc;
 	int prev_found = 0;
 	uint64_t wlk_addr;
+	uint64_t end_addr;
 	uint64_t rd_addr = 0;
 	uint64_t wlk_prev_addr = 0;
 	uint32_t cnt_his;
 	struct zms_ate wlk_ate;
+	int32_t loop_count = 0;
 #ifdef CONFIG_ZMS_DATA_CRC
 	uint32_t computed_data_crc;
 #endif
@@ -1557,21 +1745,56 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	cnt_his = 0U;
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
-
+#define ID_MATCH_RANGE 1
+	const uint32_t id_min =
+		(fs->last_read_id > ID_MATCH_RANGE) ? (fs->last_read_id - ID_MATCH_RANGE) : 0;
+	const uint32_t id_max = (fs->last_read_id < UINT32_MAX - ID_MATCH_RANGE)
+					? (fs->last_read_id + ID_MATCH_RANGE)
+					: UINT32_MAX;
+	if ((id >= id_min) && (id <= id_max) && (fs->last_read_addr != ZMS_LOOKUP_CACHE_NO_ADDR)) {
+		wlk_addr = fs->last_read_addr;
+		if (id > fs->last_read_id) {
+			const uint32_t d = id - fs->last_read_id;
+			uint32_t i = 0;
+			for (; i < d; ++i) {
+				// TODO: this is a primitive heuristic; implement a real
+				// function
+				const uint64_t next_addr = wlk_addr - fs->ate_size;
+				uint64_t t = next_addr;
+				rc = zms_compute_prev_addr(fs, &t);
+				if ((rc < 0) || (t != wlk_addr)) {
+					wlk_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+					break;
+				}
+				wlk_addr = next_addr;
+			}
+			LOG_DBG("%s: %s: larger id: %u, cnt: %d, prev_id: %u, addr: "
+				"0x%0x'%08x, i: %d",
+				__func__, (fs->name) ? fs->name : "?", id, cnt, fs->last_read_id,
+				(uint32_t)(wlk_addr >> 32), (uint32_t)(wlk_addr & INT32_MAX), i);
+		}
+		end_addr = wlk_addr;
+	} else {
+		wlk_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+	}
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
-		rc = -ENOENT;
-		goto err;
+		wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
+		if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
+			rc = -ENOENT;
+			goto err;
+		}
+		end_addr = fs->ate_wra;
 	}
 #else
 	wlk_addr = fs->ate_wra;
+	end_addr = wlk_addr;
 #endif
 
 	while (cnt_his <= cnt) {
 		wlk_prev_addr = wlk_addr;
 		/* Search for a previous valid ATE with the same ID */
-		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate,
-						  &wlk_prev_addr);
+		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, end_addr, &wlk_ate,
+						  &wlk_prev_addr, &loop_count);
 		if (prev_found < 0) {
 			return prev_found;
 		}
@@ -1593,6 +1816,17 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 			break;
 		}
 	}
+
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+	LOG_DBG("%s: %s: id: %u, cnt: %d, prev_id: %u, addr: 0x%0x'%08x, ate loops: %d", __func__,
+		(fs->name) ? fs->name : "?", id, cnt, fs->last_read_id, (uint32_t)(wlk_addr >> 32),
+		(uint32_t)(wlk_addr & INT32_MAX), loop_count);
+	if ((cnt == 0) && prev_found) {
+		fs->last_read_addr = ZMS_LOOKUP_CACHE_NO_ADDR;
+		fs->last_read_id = id;
+		fs->last_read_addr = rd_addr;
+	}
+#endif
 
 	if (((!prev_found) || (wlk_ate.id != id)) || (wlk_ate.len == 0U) || (cnt_his < cnt)) {
 		return -ENOENT;
@@ -1714,7 +1948,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 		wlk_addr = step_addr;
 		/* Try to find if there is a previous valid ATE with same ID */
 		prev_found = zms_find_ate_with_id(fs, step_ate.id, wlk_addr, step_addr, &wlk_ate,
-						  &wlk_prev_addr);
+						  &wlk_prev_addr, NULL);
 		if (prev_found < 0) {
 			return prev_found;
 		}

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -51,7 +51,7 @@ int zms_get_lowest_id_in_use(const struct zms_fs *fs, uint32_t *id)
 
 int32_t zms_get_num_entries(const struct zms_fs *fs)
 {
-	return fs->num_entries;
+	return fs->num_valid_ates;
 }
 
 static int zms_ate_crc8_check(const struct zms_ate *entry);
@@ -121,7 +121,7 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 	fs->lowest_id_in_use = UINT32_MAX;
 	fs->highest_id_in_use_valid = false;
 	fs->lowest_id_in_use_valid = false;
-	fs->num_entries = 0;
+	fs->num_valid_ates = 0;
 
 	addr = fs->ate_wra;
 
@@ -160,19 +160,17 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 						cache_entry - fs->lookup_cache, ate.id,
 						(uint32_t)(ate_addr >> 32), (uint32_t)ate_addr);
 				}
-				if (ate.id < 0x7ffffffeUL) { /* TODO: FIXME: remove this */
-					if ((ate.id > fs->highest_id_in_use) ||
-					    (!fs->highest_id_in_use_valid)) {
-						fs->highest_id_in_use = ate.id;
-						fs->highest_id_in_use_valid = true;
-					}
-					if ((ate.id < fs->lowest_id_in_use) ||
-					    (!fs->lowest_id_in_use_valid)) {
-						fs->lowest_id_in_use = ate.id;
-						fs->lowest_id_in_use_valid = true;
-					}
+				if ((ate.id > fs->highest_id_in_use) ||
+				    (!fs->highest_id_in_use_valid)) {
+					fs->highest_id_in_use = ate.id;
+					fs->highest_id_in_use_valid = true;
 				}
-				++fs->num_entries;
+				if ((ate.id < fs->lowest_id_in_use) ||
+				    (!fs->lowest_id_in_use_valid)) {
+					fs->lowest_id_in_use = ate.id;
+					fs->lowest_id_in_use_valid = true;
+				}
+				++fs->num_valid_ates;
 			}
 			previous_sector_num = SECTOR_NUM(ate_addr);
 		}
@@ -203,7 +201,7 @@ static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 	fs->lowest_id_in_use = UINT32_MAX;
 	fs->highest_id_in_use_valid = false;
 	fs->lowest_id_in_use_valid = false;
-	fs->num_entries = -1;
+	fs->num_valid_ates = -1;
 }
 
 #endif /* CONFIG_ZMS_LOOKUP_CACHE */
@@ -1571,36 +1569,23 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 			else {
 				if (fs->invalidate_old_ates) {
 					zms_invalidate_ate(&wlk_ate);
-					// TODO: I think we don't need to
-					// k_mutex_lock(&fs->zms_lock, K_FOREVER); for this, right?
 					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
 							      sizeof(wlk_ate));
 					if (rc < 0) {
 						return rc;
 					}
+					// Between invalidating an old entry in flash and until
+					// completing writing the new entry, there is a time where
+					// concurrent readers see an unexpected -ENOENT.
+					// TODO: we could try to protect this using a read mutex,
+					// but I consider that too expensive atm.
 				}
-				// deleting an entry that indeed existed before
-				if (fs->highest_id_in_use_valid && (fs->highest_id_in_use == id)) {
-					if (id > 0) {
-						--fs->highest_id_in_use;
-						// TODO: this probably wrong; fix for delete use
-						// case
-					} else {
-						fs->highest_id_in_use_valid = false;
-						fs->lowest_id_in_use_valid = false;
-					}
-				}
-				if (fs->lowest_id_in_use_valid && (fs->lowest_id_in_use == id)) {
-					if (id < fs->highest_id_in_use) {
-						++fs->lowest_id_in_use;
-					}
-				} else {
-					fs->highest_id_in_use_valid = false;
-					fs->lowest_id_in_use_valid = false;
-				}
+				// Deleting an entry that indeed existed before
+				// We don't try to track highest and lowest id in use here:
+				// it would require rescanning all ATEs to be correct
 			}
-			if (fs->num_entries >= 0) {
-				--fs->num_entries;
+			if (fs->num_valid_ates >= 0) {
+				--fs->num_valid_ates;
 			}
 #endif
 		} else if (len == wlk_ate.len) {
@@ -1643,8 +1628,8 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 		if (len == 0) {
 			return 0;
 		}
-		if (fs->num_entries >= 0) {
-			++fs->num_entries;
+		if (fs->num_valid_ates >= 0) {
+			++fs->num_valid_ates;
 		}
 	}
 #endif

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -25,6 +25,7 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 					  uint8_t cycle_cnt);
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
+BUILD_ASSERT(UINT32_MAX == ZMS_HEAD_ID);
 #define ZMS_DONT_KEEP_HISTORY 1
 
 static inline const char *get_fs_name(const struct zms_fs *fs)
@@ -1704,9 +1705,11 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	/* Search for a previous valid ATE with the same ID */
 	struct zms_ate wlk_ate;
 	int prev_found = -1;
-	if (fs->highest_id_in_use_valid && (fs->highest_id_in_use < id)) {
+	if (fs->invalidate_old_ates && fs->highest_id_in_use_valid &&
+	    (fs->highest_id_in_use < id)) {
 		prev_found = 0;
-	} else if (fs->lowest_id_in_use_valid && (fs->lowest_id_in_use > id)) {
+	} else if (fs->invalidate_old_ates && fs->lowest_id_in_use_valid &&
+		   (fs->lowest_id_in_use > id)) {
 		prev_found = 0;
 	} else {
 		prev_found = zms_find_ate_with_id(fs, id, wlk_addr, fs->ate_wra, &wlk_ate, &rd_addr,

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1569,12 +1569,15 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 			}
 #ifdef ZMS_DONT_KEEP_HISTORY
 			else {
-				zms_invalidate_ate(&wlk_ate);
-				// TODO: I think we don't need to k_mutex_lock(&fs->zms_lock,
-				// K_FOREVER); for this, right?
-				rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate, sizeof(wlk_ate));
-				if (rc < 0) {
-					return rc;
+				if (fs->invalidate_old_ates) {
+					zms_invalidate_ate(&wlk_ate);
+					// TODO: I think we don't need to
+					// k_mutex_lock(&fs->zms_lock, K_FOREVER); for this, right?
+					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
+							      sizeof(wlk_ate));
+					if (rc < 0) {
+						return rc;
+					}
 				}
 				// deleting an entry that indeed existed before
 				if (fs->highest_id_in_use_valid && (fs->highest_id_in_use == id)) {
@@ -1609,7 +1612,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 					return 0;
 				}
 #ifdef ZMS_DONT_KEEP_HISTORY
-				else {
+				else if (fs->invalidate_old_ates) {
 					zms_invalidate_ate(&wlk_ate);
 					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
 							      sizeof(wlk_ate));
@@ -1624,7 +1627,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 					return rc;
 				}
 #ifdef ZMS_DONT_KEEP_HISTORY
-				else {
+				else if (fs->invalidate_old_ates) {
 					zms_invalidate_ate(&wlk_ate);
 					rc = zms_flash_al_wrt(fs, ate_addr, &wlk_ate,
 							      sizeof(wlk_ate));
@@ -1708,8 +1711,8 @@ no_cached_entry:
 		fs->lowest_id_in_use = id;
 		fs->lowest_id_in_use_valid = true;
 	}
-	LOG_DBG("%s: %s: ate search loops: %d, gc loops: %d (max. %d) for id: %u", __func__,
-		(fs->name) ? fs->name : "?", loop_count, gc_count, fs->sector_count, id);
+	LOG_DBG("%s: %s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d)", __func__,
+		(fs->name) ? fs->name : "?", id, len, loop_count, gc_count, fs->sector_count);
 #endif
 
 end:
@@ -1751,12 +1754,12 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	const uint32_t id_max = (fs->last_read_id < UINT32_MAX - ID_MATCH_RANGE)
 					? (fs->last_read_id + ID_MATCH_RANGE)
 					: UINT32_MAX;
-	if ((id >= id_min) && (id <= id_max) && (fs->last_read_addr != ZMS_LOOKUP_CACHE_NO_ADDR)) {
+	if (fs->invalidate_old_ates && (id >= id_min) && (id <= id_max) &&
+	    (fs->last_read_addr != ZMS_LOOKUP_CACHE_NO_ADDR)) {
 		wlk_addr = fs->last_read_addr;
 		if (id > fs->last_read_id) {
 			const uint32_t d = id - fs->last_read_id;
-			uint32_t i = 0;
-			for (; i < d; ++i) {
+			for (uint32_t i = 0; i < d; ++i) {
 				// TODO: this is a primitive heuristic; implement a real
 				// function
 				const uint64_t next_addr = wlk_addr - fs->ate_size;
@@ -1768,10 +1771,6 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 				}
 				wlk_addr = next_addr;
 			}
-			LOG_DBG("%s: %s: larger id: %u, cnt: %d, prev_id: %u, addr: "
-				"0x%0x'%08x, i: %d",
-				__func__, (fs->name) ? fs->name : "?", id, cnt, fs->last_read_id,
-				(uint32_t)(wlk_addr >> 32), (uint32_t)(wlk_addr & INT32_MAX), i);
 		}
 		end_addr = wlk_addr;
 	} else {

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -27,6 +27,11 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 #define ZMS_DONT_KEEP_HISTORY 1
 
+static inline const char *get_fs_name(const struct zms_fs *fs)
+{
+	return (fs->name) ? fs->name : "?";
+}
+
 int zms_get_highest_id_in_use(const struct zms_fs *fs, uint32_t *id)
 {
 	if (!fs->highest_id_in_use_valid) {
@@ -67,9 +72,8 @@ static void zms_invalidate_ate(struct zms_ate *ate)
 		const uint8_t orig_crc = ate->crc8;
 		ate->crc8 = orig_crc & ~lsb; // make the lowest 1 bit -> 0
 		if (zms_ate_crc8_check(ate)) {
-			LOG_DBG("%s: wrote invalid crc8 0x%x for id %u (by deleting 0x%x from "
-				"0x%x)",
-				__func__, ate->crc8, ate->id, lsb, orig_crc);
+			LOG_DBG("wrote invalid crc8 0x%x for id %u (by deleting 0x%x from 0x%x)",
+				ate->crc8, ate->id, lsb, orig_crc);
 			return;
 		} else {
 			LOG_ERR("%s: could not invalidate crc8 0x%x for id %u (by deleting 0x%x "
@@ -80,7 +84,7 @@ static void zms_invalidate_ate(struct zms_ate *ate)
 	// It should always be possible to write the all-0 ate
 	memset(ate, 0, sizeof(struct zms_ate));
 	if (zms_ate_crc8_check(ate)) {
-		LOG_DBG("%s: wrote invalid all-0 ate", __func__);
+		LOG_DBG("wrote invalid all-0 ate");
 		return;
 	}
 	// This LOG_ERR() is never hit: the all-0 ate is in fact invalid
@@ -146,14 +150,7 @@ static void zms_read_cache_update(struct zms_fs *fs, uint32_t id, uint64_t ate_a
 	if (strange && fs->invalidate_old_ates) {
 		LOG_WRN("%s: %s: id: %u, e: %d, b: %d, num_valid_ates: %d, highest_id_in_use: %u "
 			"(%svalid), lowest_id_in_use: %u (%svalid)",
-			__func__, fs->name ? fs->name : "?", id, exists_now, existed_before,
-			fs->num_valid_ates, fs->highest_id_in_use,
-			fs->highest_id_in_use_valid ? "" : "in", fs->lowest_id_in_use,
-			fs->lowest_id_in_use_valid ? "" : "in");
-	} else {
-		LOG_DBG("%s: %s: id: %u, e: %d, b: %d, num_valid_ates: %d, highest_id_in_use: %u "
-			"(%svalid), lowest_id_in_use: %u (%svalid)",
-			__func__, fs->name ? fs->name : "?", id, exists_now, existed_before,
+			__func__, get_fs_name(fs), id, exists_now, existed_before,
 			fs->num_valid_ates, fs->highest_id_in_use,
 			fs->highest_id_in_use_valid ? "" : "in", fs->lowest_id_in_use,
 			fs->lowest_id_in_use_valid ? "" : "in");
@@ -278,11 +275,10 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 			if (zms_ate_valid_different_sector(fs, &ate, current_cycle)) {
 				if (*cache_entry == ZMS_LOOKUP_CACHE_NO_ADDR) {
 					*cache_entry = ate_addr;
-					LOG_DBG("%s: %s: assigned cache entry %2d: id %10u -> "
-						"%3d:0x%08x",
-						__func__, (fs->name) ? fs->name : "?",
-						cache_entry - fs->lookup_cache, ate.id,
-						(uint32_t)(ate_addr >> 32), (uint32_t)ate_addr);
+					LOG_DBG("%s: assigned cache entry %2d: id %10u -> "
+						"0x%llx",
+						get_fs_name(fs), cache_entry - fs->lookup_cache,
+						ate.id, ate_addr);
 				}
 				zms_read_cache_update(fs, ate.id, ate_addr, true, false);
 			}
@@ -293,8 +289,7 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 			break;
 		}
 	}
-	LOG_DBG("%s: done for fs %s, loop_count: %d", __func__, (fs->name) ? fs->name : "?",
-		loop_count);
+	LOG_DBG("done for fs %s, loop_count: %d", get_fs_name(fs), loop_count);
 
 	return 0;
 }
@@ -313,6 +308,14 @@ static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 		fs->last_read[i].addr = ZMS_LOOKUP_CACHE_NO_ADDR;
 		fs->last_read[i].id = UINT32_MAX;
 	}
+}
+
+#else /* CONFIG_ZMS_LOOKUP_CACHE */
+
+static inline const char *get_fs_name(const struct zms_fs *fs)
+{
+	ARG_UNUSED(fs);
+	return "?";
 }
 
 #endif /* CONFIG_ZMS_LOOKUP_CACHE */
@@ -553,8 +556,8 @@ static int zms_flash_erase_sector(struct zms_fs *fs, uint64_t addr)
 	addr &= ADDR_SECT_MASK;
 	offset = zms_addr_to_offset(fs, addr);
 
-	LOG_DBG("Erasing flash at offset 0x%lx ( 0x%llx ), len %u", (long)offset, addr,
-		fs->sector_size);
+	LOG_DBG("%s: erasing flash at offset 0x%lx ( 0x%llx ), len %u", get_fs_name(fs),
+		(long)offset, addr, fs->sector_size);
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	zms_lookup_cache_invalidate(fs, SECTOR_NUM(addr));
@@ -566,7 +569,8 @@ static int zms_flash_erase_sector(struct zms_fs *fs, uint64_t addr)
 	}
 
 	if (zms_flash_cmp_const(fs, addr, fs->flash_parameters->erase_value, fs->sector_size)) {
-		LOG_ERR("Failure while erasing the sector at offset 0x%lx", (long)offset);
+		LOG_ERR("%s: %s: failure while erasing the sector at offset 0x%lx", __func__,
+			get_fs_name(fs), (long)offset);
 		rc = -ENXIO;
 	}
 
@@ -768,7 +772,7 @@ static int zms_recover_last_ate(struct zms_fs *fs, uint64_t *addr, uint64_t *dat
 	struct zms_ate end_ate;
 	int rc;
 
-	LOG_DBG("Recovering last ate from sector %llu", SECTOR_NUM(*addr));
+	LOG_DBG("%s: recovering last ate from sector %llu", get_fs_name(fs), SECTOR_NUM(*addr));
 
 	/* skip close and empty ATE */
 	*addr -= 2 * fs->ate_size;
@@ -921,7 +925,7 @@ static int zms_add_gc_done_ate(struct zms_fs *fs)
 {
 	struct zms_ate gc_done_ate;
 
-	LOG_DBG("Adding gc done ate at %llx", fs->ate_wra);
+	LOG_DBG("%s: adding gc done ate at %llx", get_fs_name(fs), fs->ate_wra);
 	gc_done_ate.id = ZMS_HEAD_ID;
 	gc_done_ate.len = 0U;
 	gc_done_ate.offset = (uint32_t)SECTOR_OFFSET(fs->data_wra);
@@ -942,7 +946,8 @@ static int zms_add_empty_ate(struct zms_fs *fs, uint64_t addr)
 
 	addr &= ADDR_SECT_MASK;
 
-	LOG_DBG("Adding empty ate at %llx", (uint64_t)(addr + fs->sector_size - fs->ate_size));
+	LOG_DBG("%s: adding empty ate at %llx", get_fs_name(fs),
+		(uint64_t)(addr + fs->sector_size - fs->ate_size));
 	empty_ate.id = ZMS_HEAD_ID;
 	empty_ate.len = 0xffff;
 	empty_ate.offset = 0U;
@@ -1105,10 +1110,9 @@ static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_a
 		}
 	}
 	if (*loop_cnt >= 100000) {
-		LOG_DBG("%s: loop_cnt: %d, id: %d, sa: 0x%llx, ea: 0x%llx, atea: "
-			"0x%llx, wa: 0x%llx, wpa: 0x%llx, first_sect_border_seen: "
-			"%d @ 0x%x",
-			__func__, *loop_cnt, id, start_addr, end_addr, *ate_addr, wlk_addr,
+		LOG_DBG("%s: loop_cnt: %d, id: %d, sa: 0x%llx, ea: 0x%llx, atea: 0x%llx, wa: "
+			"0x%llx, wpa: 0x%llx, first_sect_border_seen: %d @ 0x%x",
+			get_fs_name(fs), *loop_cnt, id, start_addr, end_addr, *ate_addr, wlk_addr,
 			wlk_prev_addr, first_sect_border_seen, end_sect);
 	}
 	return prev_found;
@@ -1235,7 +1239,7 @@ static int zms_gc(struct zms_fs *fs)
 		 */
 		if (wlk_prev_addr == gc_prev_addr) {
 			/* copy needed */
-			LOG_DBG("Moving %d, len %d", gc_ate.id, gc_ate.len);
+			LOG_DBG("%s: moving %d, len %d", get_fs_name(fs), gc_ate.id, gc_ate.len);
 
 			if (gc_ate.len > ZMS_DATA_IN_ATE_SIZE) {
 				/* Copy Data only when len > 8
@@ -1294,7 +1298,7 @@ int zms_clear(struct zms_fs *fs)
 	uint64_t addr;
 
 	if (!fs->ready) {
-		LOG_ERR("zms not initialized");
+		LOG_ERR("%s: %s: zms not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 
@@ -1360,7 +1364,9 @@ static int zms_init(struct zms_fs *fs)
 				zms_magic_exist = true;
 				/* Let's check that we support this ZMS version */
 				if (ZMS_GET_VERSION(empty_ate.metadata) != ZMS_DEFAULT_VERSION) {
-					LOG_ERR("ZMS Version is not supported");
+					LOG_ERR("%s: %s: ZMS Version %lu is not supported",
+						__func__, get_fs_name(fs),
+						ZMS_GET_VERSION(empty_ate.metadata));
 					rc = -EPROTONOSUPPORT;
 					goto end;
 				}
@@ -1416,7 +1422,9 @@ static int zms_init(struct zms_fs *fs)
 				zms_magic_exist = true;
 				/* Let's check the version */
 				if (ZMS_GET_VERSION(empty_ate.metadata) != ZMS_DEFAULT_VERSION) {
-					LOG_ERR("ZMS Version is not supported");
+					LOG_ERR("%s: %s: ZMS Version %lu is not supported",
+						__func__, get_fs_name(fs),
+						ZMS_GET_VERSION(empty_ate.metadata));
 					rc = -EPROTONOSUPPORT;
 					goto end;
 				}
@@ -1525,7 +1533,7 @@ static int zms_init(struct zms_fs *fs)
 
 		if (gc_done_marker) {
 			/* erase the next sector */
-			LOG_INF("GC Done marker found");
+			LOG_INF("%s: %s: GC Done marker found", __func__, get_fs_name(fs));
 			addr = fs->ate_wra & ADDR_SECT_MASK;
 			zms_sector_advance(fs, &addr);
 			rc = zms_flash_erase_sector(fs, addr);
@@ -1535,7 +1543,8 @@ static int zms_init(struct zms_fs *fs)
 			rc = zms_add_empty_ate(fs, addr);
 			goto end;
 		}
-		LOG_INF("No GC Done marker found: restarting gc");
+		LOG_INF("%s: %s: no GC Done marker found: restarting gc", __func__,
+			get_fs_name(fs));
 		rc = zms_flash_erase_sector(fs, fs->ate_wra);
 		if (rc) {
 			goto end;
@@ -1590,7 +1599,7 @@ int zms_mount(struct zms_fs *fs)
 
 	fs->flash_parameters = flash_get_parameters(fs->flash_device);
 	if (fs->flash_parameters == NULL) {
-		LOG_ERR("Could not obtain flash parameters");
+		LOG_ERR("%s: %s: could not obtain flash parameters", __func__, get_fs_name(fs));
 		return -EINVAL;
 	}
 
@@ -1599,7 +1608,7 @@ int zms_mount(struct zms_fs *fs)
 
 	/* check that the write block size is supported */
 	if (write_block_size > ZMS_BLOCK_SIZE || write_block_size == 0) {
-		LOG_ERR("Unsupported write block size");
+		LOG_ERR("%s: %s: unsupported write block size", __func__, get_fs_name(fs));
 		return -EINVAL;
 	}
 
@@ -1609,11 +1618,11 @@ int zms_mount(struct zms_fs *fs)
 	if (flash_params_get_erase_cap(fs->flash_parameters) & FLASH_ERASE_C_EXPLICIT) {
 		rc = flash_get_page_info_by_offs(fs->flash_device, fs->offset, &info);
 		if (rc) {
-			LOG_ERR("Unable to get page info");
+			LOG_ERR("%s: %s: unable to get page info", __func__, get_fs_name(fs));
 			return -EINVAL;
 		}
 		if (!fs->sector_size || fs->sector_size % info.size) {
-			LOG_ERR("Invalid sector size");
+			LOG_ERR("%s: %s: invalid sector size", __func__, get_fs_name(fs));
 			return -EINVAL;
 		}
 	}
@@ -1622,13 +1631,14 @@ int zms_mount(struct zms_fs *fs)
 	 * 1 close ATE, 1 empty ATE, 1 GC done ATE, 1 Delete ATE, 1 ID/Value ATE
 	 */
 	if (fs->sector_size < ZMS_MIN_ATE_NUM * fs->ate_size) {
-		LOG_ERR("Invalid sector size, should be at least %zu",
-			ZMS_MIN_ATE_NUM * fs->ate_size);
+		LOG_ERR("%s: %s: invalid sector size, should be at least %zu", __func__,
+			get_fs_name(fs), ZMS_MIN_ATE_NUM * fs->ate_size);
 	}
 
 	/* check the number of sectors, it should be at least 2 */
 	if (fs->sector_count < 2) {
-		LOG_ERR("Configuration error - sector count below minimum requirement (2)");
+		LOG_ERR("%s: %s: configuration error - sector count below minimum requirement (2)",
+			__func__, get_fs_name(fs));
 		return -EINVAL;
 	}
 
@@ -1641,9 +1651,12 @@ int zms_mount(struct zms_fs *fs)
 	/* zms is ready for use */
 	fs->ready = true;
 
-	LOG_INF("%u Sectors of %u bytes", fs->sector_count, fs->sector_size);
-	LOG_INF("alloc wra: %llu, %llx", SECTOR_NUM(fs->ate_wra), SECTOR_OFFSET(fs->ate_wra));
-	LOG_INF("data wra: %llu, %llx", SECTOR_NUM(fs->data_wra), SECTOR_OFFSET(fs->data_wra));
+	LOG_INF("%s: %s: %u Sectors of %u bytes", __func__, get_fs_name(fs), fs->sector_count,
+		fs->sector_size);
+	LOG_INF("%s: %s: alloc wra: %llu, %llx", __func__, get_fs_name(fs), SECTOR_NUM(fs->ate_wra),
+		SECTOR_OFFSET(fs->ate_wra));
+	LOG_INF("%s: %s: data wra: %llu, %llx", __func__, get_fs_name(fs), SECTOR_NUM(fs->data_wra),
+		SECTOR_OFFSET(fs->data_wra));
 
 	return 0;
 }
@@ -1659,7 +1672,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	int32_t loop_count = 0;
 
 	if (!fs->ready) {
-		LOG_ERR("zms not initialized");
+		LOG_ERR("%s: %s: zms not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 
@@ -1822,12 +1835,14 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 		}
 		rc = zms_sector_close(fs);
 		if (rc) {
-			LOG_ERR("Failed to close the sector, returned = %d", rc);
+			LOG_ERR("%s: %s: failed to close the sector, returned = %d", __func__,
+				get_fs_name(fs), rc);
 			goto end;
 		}
 		rc = zms_gc(fs);
 		if (rc) {
-			LOG_ERR("Garbage collection failed, returned = %d", rc);
+			LOG_ERR("%s: %s: garbage collection failed, returned = %d", __func__,
+				get_fs_name(fs), rc);
 			goto end;
 		}
 		gc_count++;
@@ -1835,10 +1850,10 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	rc = len;
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	zms_read_cache_update(fs, id, fs->ate_wra, true, prev_found > 0);
-	LOG_DBG("%s: %s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d), "
+	LOG_DBG("%s: id: %u, len: %d, ate search loops: %d, gc loops: %d (max. %d), "
 		"num_valid_ates: %d, lowest id: %u, highest id: %u",
-		__func__, (fs->name) ? fs->name : "?", id, len, loop_count, gc_count,
-		fs->sector_count, fs->num_valid_ates, fs->lowest_id_in_use, fs->highest_id_in_use);
+		get_fs_name(fs), id, len, loop_count, gc_count, fs->sector_count,
+		fs->num_valid_ates, fs->lowest_id_in_use, fs->highest_id_in_use);
 #endif
 
 end:
@@ -1867,7 +1882,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 #endif
 
 	if (!fs->ready) {
-		LOG_ERR("zms not initialized");
+		LOG_ERR("%s: %s: zms not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 
@@ -1930,8 +1945,8 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 	}
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	LOG_DBG("%s: %s: id: %u, cnt: %d, addr: 0x%llx, ate loops: %d", __func__,
-		(fs->name) ? fs->name : "?", id, cnt, wlk_addr, loop_count);
+	LOG_DBG("%s: id: %u, cnt: %d, addr: 0x%llx, ate loops: %d", get_fs_name(fs), id, cnt,
+		wlk_addr, loop_count);
 	if (cnt == 0) {
 		zms_read_cache_update(fs, id, rd_addr, prev_found > 0, true);
 	}
@@ -1961,9 +1976,10 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 		if (len >= wlk_ate.len) {
 			computed_data_crc = crc32_ieee(data, wlk_ate.len);
 			if (computed_data_crc != wlk_ate.data_crc) {
-				LOG_ERR("Invalid data CRC: ATE_CRC=0x%08X, "
+				LOG_ERR("%s: %s: invalid data CRC: ATE_CRC=0x%08X, "
 					"computed_data_crc=0x%08X",
-					wlk_ate.data_crc, computed_data_crc);
+					__func__, get_fs_name(fs), wlk_ate.data_crc,
+					computed_data_crc);
 				return -EIO;
 			}
 		}
@@ -2018,7 +2034,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 	const uint32_t second_to_last_offset = (2 * fs->ate_size);
 
 	if (!fs->ready) {
-		LOG_ERR("zms not initialized");
+		LOG_ERR("%s: %s: zms not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 
@@ -2116,7 +2132,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 size_t zms_active_sector_free_space(struct zms_fs *fs)
 {
 	if (!fs->ready) {
-		LOG_ERR("ZMS not initialized");
+		LOG_ERR("%s: %s: ZMS not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 
@@ -2128,7 +2144,7 @@ int zms_sector_use_next(struct zms_fs *fs)
 	int ret;
 
 	if (!fs->ready) {
-		LOG_ERR("ZMS not initialized");
+		LOG_ERR("%s: %s: ZMS not initialized", __func__, get_fs_name(fs));
 		return -EACCES;
 	}
 

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -80,11 +80,13 @@ int settings_load_subtree_direct(
 	 *    apply config
 	 *    commit all
 	 */
+	LOG_DBG("%s: start subtree: %s", __func__, (subtree) ? subtree : "(null)");
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
 		cs->cs_itf->csi_load(cs, &arg);
 	}
 	k_mutex_unlock(&settings_lock);
+	LOG_DBG("%s: end subtree: %s", __func__, (subtree) ? subtree : "(null)");
 	return 0;
 }
 

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -80,13 +80,13 @@ int settings_load_subtree_direct(
 	 *    apply config
 	 *    commit all
 	 */
-	LOG_DBG("%s: start subtree: %s", __func__, (subtree) ? subtree : "(null)");
+	LOG_DBG("start subtree: %s", (subtree) ? subtree : "(null)");
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
 		cs->cs_itf->csi_load(cs, &arg);
 	}
 	k_mutex_unlock(&settings_lock);
-	LOG_DBG("%s: end subtree: %s", __func__, (subtree) ? subtree : "(null)");
+	LOG_DBG("end subtree: %s", (subtree) ? subtree : "(null)");
 	return 0;
 }
 

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -182,7 +182,7 @@ static int settings_zms_load(struct settings_store *cs, const struct settings_lo
 		rc2 = zms_get_data_length(&cf->cf_zms, ZMS_NAME_ID_FROM_LL_NODE(ll_hash_id) +
 							       ZMS_DATA_ID_OFFSET);
 
-		LOG_DBG("%s: ll_hash_id: %d, loop count: %d, rc1: %d, rc2: %d", __func__, ll_hash_id, loop_count, rc1, rc2);
+		LOG_DBG("ll_hash_id: %d, loop count: %d, rc1: %d, rc2: %d", ll_hash_id, loop_count, rc1, rc2);
 		if ((rc1 <= 0) || (rc2 <= 0)) {
 			/* Settings item is not stored correctly in the ZMS.
 			 * ZMS entry for its name or value is either missing
@@ -216,7 +216,7 @@ static int settings_zms_load(struct settings_store *cs, const struct settings_lo
 		ll_hash_id = settings_element.next_hash;
 	}
 
-	LOG_DBG("%s: done, ll_hash_id: %d, loop count: %d, ret: %d", __func__, ll_hash_id, loop_count, ret);
+	LOG_DBG("done, ll_hash_id: %d, loop count: %d, ret: %d", ll_hash_id, loop_count, ret);
 	return ret;
 }
 

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -163,6 +163,7 @@ static int settings_zms_load(struct settings_store *cs, const struct settings_lo
 		return ret;
 	}
 	ll_hash_id = settings_element.next_hash;
+	int loop_count = 0;
 
 	while (ll_hash_id) {
 
@@ -170,12 +171,18 @@ static int settings_zms_load(struct settings_store *cs, const struct settings_lo
 		 * entries one for the setting's name and one with the
 		 * setting's value.
 		 */
+		++loop_count;
+		if ((loop_count % 1000) == 0) {
+			LOG_ERR("%s: loop count is %d", __func__, loop_count);
+		}
+
 		rc1 = zms_read(&cf->cf_zms, ZMS_NAME_ID_FROM_LL_NODE(ll_hash_id), &name,
 			       sizeof(name) - 1);
 		/* get the length of data and verify that it exists */
 		rc2 = zms_get_data_length(&cf->cf_zms, ZMS_NAME_ID_FROM_LL_NODE(ll_hash_id) +
 							       ZMS_DATA_ID_OFFSET);
 
+		LOG_DBG("%s: ll_hash_id: %d, loop count: %d, rc1: %d, rc2: %d", __func__, ll_hash_id, loop_count, rc1, rc2);
 		if ((rc1 <= 0) || (rc2 <= 0)) {
 			/* Settings item is not stored correctly in the ZMS.
 			 * ZMS entry for its name or value is either missing
@@ -209,6 +216,7 @@ static int settings_zms_load(struct settings_store *cs, const struct settings_lo
 		ll_hash_id = settings_element.next_hash;
 	}
 
+	LOG_DBG("%s: done, ll_hash_id: %d, loop count: %d, ret: %d", __func__, ll_hash_id, loop_count, ret);
 	return ret;
 }
 


### PR DESCRIPTION
Using CONFIG_ZMS_LOOKUP_CACHE + CONFIG_ZMS_NO_DOUBLE_WRITE and the ability to invalidate old ATEs (by writing 0s over 1s in flash) to make sure there is max. one valid ATE per ID.
This allows to use the first found valid ATE per ID, and thus to use the address of the last found close-by ID as a starting address to search. In the use case where IDs are (usually) written and read consecutively this speeds up consecutive reads to near constant time (from O(N)). Furthermore, some stats like entries count should be possible and are draft implemented.